### PR TITLE
Color themes

### DIFF
--- a/assets/scaffold.scss
+++ b/assets/scaffold.scss
@@ -19,16 +19,14 @@ $buttonHoverTextColor: {{ .Site.Params.buttonHoverTextColor | default "white" }}
 $buttonHoverBgColor: {{ .Site.Params.buttonHoverBgColor | default "blue" }};
 $borderColor: {{ .Site.Params.borderColor | default "moon-gray" }};
 
-
 // learn about Tachyons http://tachyons.io
 @import 'tachyons';
 
-// uncomment the import below to activate custom-colors
-// add your own colors at the top of the imported file
-@import '{{ $.Site.Data.theme.colors.theme | default "blue" }}';
-// @import 'grayscale';
-// @import 'forest';
-// @import 'violet';
+// colors set in data/theme.yaml
+// one of: blue / forest / grayscale / violet
+{{ with $.Site.Data.theme.colors.theme }}
+@import '{{ . | default "blue" }}';
+{{ end }}
 
 // uncomment the import below to activate custom-fonts
 // add your own fonts at the top of the imported file

--- a/assets/scaffold.scss
+++ b/assets/scaffold.scss
@@ -25,9 +25,7 @@ $borderColor: {{ .Site.Params.borderColor | default "moon-gray" }};
 
 // uncomment the import below to activate custom-colors
 // add your own colors at the top of the imported file
-{{ with $.Site.Data.theme.colors.theme }}
-@import '{{ . | default "blue" }}';
-{{ end }}
+@import '{{ $.Site.Data.theme.colors.theme | default "blue" }}';
 // @import 'grayscale';
 // @import 'forest';
 // @import 'violet';

--- a/assets/scaffold.scss
+++ b/assets/scaffold.scss
@@ -19,11 +19,15 @@ $buttonHoverTextColor: {{ .Site.Params.buttonHoverTextColor | default "white" }}
 $buttonHoverBgColor: {{ .Site.Params.buttonHoverBgColor | default "blue" }};
 $borderColor: {{ .Site.Params.borderColor | default "moon-gray" }};
 
+
 // learn about Tachyons http://tachyons.io
 @import 'tachyons';
+
 // uncomment the import below to activate custom-colors
 // add your own colors at the top of the imported file
-@import 'blue';
+{{ with $.Site.Data.theme.colors.theme }}
+@import '{{ . | default "blue" }}';
+{{ end }}
 // @import 'grayscale';
 // @import 'forest';
 // @import 'violet';

--- a/data/theme.yaml
+++ b/data/theme.yaml
@@ -5,5 +5,6 @@ fonts:
   customheadingFontFamily: "Fraunces"
   navallcaps: true
 colors:
-  # theme options: blue (default) / forest / grayscale / violet
+  # theme options: blue / forest / grayscale / violet
+  # if none, defaults to tachyons (override in config.toml)
   theme: "violet"

--- a/data/theme.yaml
+++ b/data/theme.yaml
@@ -4,3 +4,6 @@ fonts:
   customtextFontFamily: "Commissioner"
   customheadingFontFamily: "Fraunces"
   navallcaps: true
+colors:
+  # theme options: blue (default) / forest / grayscale / violet
+  theme: "violet"


### PR DESCRIPTION
adds a way to specify color theme via data/themes.yaml. Defaults to tachyons variables set in config.toml if left blank (i.e., "")