### PR TITLE
.RegularPagesRecursive

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,7 +6,7 @@
     {{ if .Params.show_author_byline }}<p class="f7 measure lh-copy tc center i">{{ if .Params.author }}Written by {{ .Params.author }}{{ end }}</p>{{ end }}
   </section>
   <section class="blog-content mw7 center">
-    {{ $paginator := .Paginate (where .Pages "Type" .Section) }}
+    {{ $paginator := .Paginate (where .RegularPagesRecursive "Type" .Section) }}
     {{ range $paginator.Pages }}
       {{ .Render "summary"}}
     {{ end }}

--- a/layouts/blog/list-grid.html
+++ b/layouts/blog/list-grid.html
@@ -9,7 +9,7 @@
     {{ if .Params.show_author_byline }}<p class="f7 measure lh-copy tc center i">{{ if .Params.author }}Written by {{ .Params.author }}{{ end }}</p>{{ end }}
   </section>
   <section class="blog-content db flex-ns flex-row-ns flex-wrap-ns items-start mw8 center">
-    {{ $paginator := .Paginate (where .Pages "Type" "blog") }}
+    {{ $paginator := .Paginate (where .RegularPagesRecursive "Type" "blog") }}
     {{ range $paginator.Pages }}
       {{ .Render "summary-grid"}}
     {{ end }}

--- a/layouts/blog/list-sidebar.html
+++ b/layouts/blog/list-sidebar.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <main class="page-main pa4 {{ .Kind }}" role="main">
   <section class="blog-content mw7 center">
-    {{ $paginator := .Paginate (where .Pages "Type" "blog") }}
+    {{ $paginator := .Paginate (where .RegularPagesRecursive "Type" "blog") }}
     {{ range $paginator.Pages }}
       {{ .Render "summary" }}
     {{ end }}

--- a/layouts/project/list-grid.html
+++ b/layouts/project/list-grid.html
@@ -6,7 +6,7 @@
     {{ if .Params.show_author_byline }}<p class="f7 measure lh-copy tc center i">{{ if .Params.author }}Written by {{ .Params.author }}{{ end }}</p>{{ end }}
   </section>
   <section class="blog-content db flex-ns flex-row-ns flex-wrap-ns items-start mw8 center">
-    {{ $pages := (where .Pages "Type" "project") }}
+    {{ $pages := (where .RegularPagesRecursive "Type" "project") }}
     {{ range $pages }}
       {{ .Render "summary-grid"}}
     {{ end }}

--- a/layouts/project/list-sidebar.html
+++ b/layouts/project/list-sidebar.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <main class="page-main pa4 {{ .Kind }}" role="main">
   <section class="blog-content mw7 center">
-    {{ $pages := (where .Pages "Type" "project") }}
+    {{ $pages := (where .RegularPagesRecursive "Type" "project") }}
     {{ range $pages }}
       {{ .Render "summary" }}
     {{ end }}


### PR DESCRIPTION
From https://gohugo.io/variables/page/#pages

`.RegularPagesRecursive`
    Collection of all regular pages under a list page. This includes regular pages in nested sections/list pages.

This feature was added in Hugo version 0.68.0